### PR TITLE
removing torchffi requirement

### DIFF
--- a/hdf5-0-0.rockspec
+++ b/hdf5-0-0.rockspec
@@ -14,7 +14,7 @@ description = {
   maintainer = "Dan Horgan <danhgn+github@gmail.com>"
 }
 
-dependencies = { 'torch >= 7.0', 'torchffi', 'logroll', 'penlight' }
+dependencies = { 'torch >= 7.0', 'logroll', 'penlight' }
 external_dependencies = { hdf5 = { library = 'hdf5' } }
 build = {
    type = "command",

--- a/luasrc/ffi.lua
+++ b/luasrc/ffi.lua
@@ -2,7 +2,6 @@ local ffi = require 'ffi'
 local bit = require 'bit'
 local stringx = require 'pl.stringx'
 local path = require 'pl.path'
-require 'torchffi'
 
 local function loadHDF5Library(libraryPaths)
     local libraries = stringx.split(libraryPaths, ";")


### PR DESCRIPTION
since torchffi is now integrated into torch, it is no longer required
