### PR TITLE
adds the ability to append to chunked files

### DIFF
--- a/luasrc/dataset.lua
+++ b/luasrc/dataset.lua
@@ -45,6 +45,11 @@ function HDF5DataSet:__init(parent, datasetID)
     hdf5._logger.debug("Initialising " .. tostring(self))
 end
 
+function HDF5DataSet:_refresh_dataspace()
+    self._dataspaceID = hdf5.C.H5Dget_space(self._datasetID)
+    return self._dataspaceID
+end
+
 function HDF5DataSet:__tostring()
     return "[HDF5DataSet " .. hdf5._describeObject(self._datasetID) .. "]"
 end
@@ -157,4 +162,10 @@ function HDF5DataSet:close()
     if status < 0 then
         error("Failed closing dataspace for " .. tostring(self))
     end
+end
+
+function HDF5DataSet:dataspaceSize()
+  local nDims = hdf5.C.H5Sget_simple_extent_ndims(self._dataspaceID)
+  local size = getDataspaceSize(nDims, self._dataspaceID)
+  return size
 end

--- a/luasrc/ffi.lua
+++ b/luasrc/ffi.lua
@@ -222,6 +222,8 @@ hdf5.H5F_OBJ_LOCAL    = 0x0020 -- Restrict search to objects opened through curr
 
 hdf5.H5P_DEFAULT = 0
 hdf5.H5S_ALL = 0
+hdf5.H5F_UNLIMITED = ffi.new('hsize_t', -1)
+hdf5.H5S_SELECT_SET = 0
 
 -- This table specifies which exact format a given type of Tensor should be saved as.
 local fileTypeMap = {

--- a/luasrc/file.lua
+++ b/luasrc/file.lua
@@ -39,25 +39,33 @@ function HDF5File:close()
 end
 
 function HDF5File:write(datapath, data, options)
+    self:_write_or_append("write", datapath, data, options)
+end
+
+function HDF5File:append(datapath, data, options)
+    self:_write_or_append("append", datapath, data, options)
+end
+
+function HDF5File:_write_or_append(method, datapath, data, options)
     if datapath:sub(1,1) == "/" then
-        datapath = datapath:sub(2)
+      datapath = datapath:sub(2)
     end
     datapath = stringx.split(datapath, "/") -- TODO
-    assert(datapath and type(datapath) == 'table', "HDF5File:write() requires a table (data path) as its first parameter")
-    assert(data and type(data) == 'userdata' or type(data) == 'table', "HDF5File:write() requires a tensor or table as its second parameter")
+    assert(datapath and type(datapath) == 'table', "HDF5File:" .. method .. "() requires a table (data path) as its first parameter")
+    assert(data and type(data) == 'userdata' or type(data) == 'table', "HDF5File:" .. method .. "() requires a tensor or table as its second parameter")
 
     if #datapath == 0 then
         if type(data) == 'table' then
             for k, v in pairs(data) do
-                self._rootGroup:write( { k }, v, options)
+                self._rootGroup[method](self._rootGroup, { k }, v, options)
             end
-            return
-        else
-            error("HDF5File:write() - must provide a table when writing to the root location")
-        end
+          return
+      else
+          error("HDF5File:write() - must provide a table when writing to the root location")
+      end
     end
 
-    self._rootGroup:write(datapath, data, options)
+    self._rootGroup[method](self._rootGroup, datapath, data, options)
 end
 
 function HDF5File:read(datapath)

--- a/luasrc/group.lua
+++ b/luasrc/group.lua
@@ -4,8 +4,16 @@ local ffi = require 'ffi'
 local HDF5Group = torch.class("hdf5.HDF5Group")
 
 --[[ Convert from LongStorage containing tensor sizes to an HDF5 hsize_t array ]]
+
 local function convertSize(size)
-    local nDims = size:size()
+    local nDims
+
+    if type(size) == 'table' then
+      nDims = #size
+    else
+      nDims = size:size()
+    end
+ 
     local size_t = hdf5.ffi.typeof("hsize_t[" .. nDims .. "]")
     local hdf5_size = size_t()
     for k = 1, nDims do
@@ -74,13 +82,17 @@ function HDF5Group:_writeDataSet(locationID, name, tensor, options)
 
     hdf5._logger.debug("Using options: " .. tostring(options))
     local dims = convertSize(tensor:size())
+    local maxDims = convertSize(tensor:size())
+    
+    if options._chunking then
+      maxDims[0] = hdf5.H5F_UNLIMITED -- array is zero indexed
+    end
 
     -- (rank, dims, maxdims)
-    local dataspaceID = hdf5.C.H5Screate_simple(tensor:nDimension(), dims, nullSize());
+    local dataspaceID = hdf5.C.H5Screate_simple(tensor:nDimension(), dims, maxDims);
 
     local typename = torch.typename(tensor)
     local fileDataType = hdf5._outputTypeForTensorType(typename)
-    local memoryDataType = hdf5._nativeTypeForTensorType(typename)
     if fileDataType == nil then
         error("Cannot find hdf5 file type for " .. typename)
     end
@@ -95,6 +107,20 @@ function HDF5Group:_writeDataSet(locationID, name, tensor, options)
             hdf5.H5P_DEFAULT
         );
 
+
+    local status = self:_writeTensorToDataSet(datasetID, tensor)
+
+    if status < 0 then
+        error("Error writing data " .. name .. " to " .. tostring(self))
+    end
+
+    local dataset = hdf5.HDF5DataSet(self, datasetID)
+    return dataset
+end
+
+function HDF5Group:_writeTensorToDataSet(datasetID, tensor)
+    local typename = torch.typename(tensor)
+    local memoryDataType = hdf5._nativeTypeForTensorType(typename)
     local status = hdf5.C.H5Dwrite(
             datasetID,
             memoryDataType,
@@ -103,12 +129,74 @@ function HDF5Group:_writeDataSet(locationID, name, tensor, options)
             hdf5.H5P_DEFAULT,
             tensor:data()
         );
-    if status < 0 then
-        error("Error writing data " .. name .. " to " .. tostring(self))
-    end
+    return status
+end
 
-    local dataset = hdf5.HDF5DataSet(self, datasetID)
-    return dataset
+-- http://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/examples/h5_extend.c
+function HDF5Group:_appendDataSet(locationID, name, tensor, options)
+  local status
+  local datasetID = hdf5.C.H5Dopen2(
+    locationID,
+    name,
+    hdf5.H5P_DEFAULT
+    );
+
+  local dataset = hdf5.HDF5DataSet(self, datasetID)
+  local dataspaceID = dataset._dataspaceID
+
+  -- Extend the dataset
+  local tensorSize = tensor:size():totable()
+  local originalSize = dataset:dataspaceSize()
+  local newSize = dataset:dataspaceSize()
+  newSize[1] = originalSize[1] + tensorSize[1]
+
+  local newSize_h = convertSize(newSize)
+
+  status = hdf5.C.H5Dset_extent(datasetID, newSize_h)
+  dataspaceID = dataset:_refresh_dataspace() -- http://www.hdfgroup.org/HDF5/doc/RM/RM_H5D.html#Dataset-SetExtent
+
+  if status < 0 then
+    error("Error extending data " .. name .. " to " .. tostring(self))
+  end
+
+  -- build the offset
+  local offset = {originalSize[1]}
+  for k = 1, (tensor:nDimension() - 1) do
+    table.insert(offset, k + 1, 0)
+  end
+
+  local offset_h = convertSize(offset)
+  local stride_h = null
+  local count_h = convertSize(tensorSize)
+
+  -- Select a hyperslab in extended portion of dataset
+  status = hdf5.C.H5Sselect_hyperslab(dataspaceID, hdf5.H5S_SELECT_SET, offset_h, stride_h, count_h, null);  
+
+  if status < 0 then
+    error("Error selecting hyperslab for data " .. name .. " to " .. tostring(self))
+  end
+
+  -- define a new memory space for the extension
+  -- TODO we may need to close this memspaceID explicitly
+  local memspaceID = hdf5.C.H5Screate_simple(tensor:nDimension(), convertSize(tensorSize), null);
+
+  -- write the data to the extended portion of the dataset
+  local typename = torch.typename(tensor)
+  local memoryDataType = hdf5._nativeTypeForTensorType(typename)
+  local status = hdf5.C.H5Dwrite(
+          datasetID,
+          memoryDataType,
+          memspaceID,
+          dataspaceID,
+          hdf5.H5P_DEFAULT,
+          tensor:data()
+      );
+
+  if status < 0 then
+    error("Error writing to hyperslab for data " .. name .. " to " .. tostring(self))
+  end
+
+  return dataset
 end
 
 local function isTensor(data)
@@ -122,6 +210,18 @@ function HDF5Group:_writeData(locationID, name, data, options)
     elseif type(data) == 'userdata' then
         if isTensor(data) then
             return self:_writeDataSet(locationID, name, data, options)
+        end
+        error("torch-hdf5: writing non-Tensor userdata is not supported")
+    end
+    error("torch-hdf5: writing data of type " .. type(data) .. " is not supported")
+end
+
+function HDF5Group:_appendData(locationID, name, data, options)
+    if type(data) == 'table' then
+        error("_appendData should not be used for tables")
+    elseif type(data) == 'userdata' then
+        if isTensor(data) then
+            return self:_appendDataSet(locationID, name, data, options)
         end
         error("torch-hdf5: writing non-Tensor userdata is not supported")
     end
@@ -146,8 +246,16 @@ function HDF5Group:getOrCreateChild(name)
 end
 
 function HDF5Group:write(datapath, data, options)
-    assert(datapath and type(datapath) == 'table', "HDF5Group:write() expects table as first parameter")
-    assert(data, "HDF5Group:write() requires data as parameter")
+    self:_write_or_append("write", datapath, data, options)
+end
+
+function HDF5Group:append(datapath, data, options)
+    self:_write_or_append("append", datapath, data, options)
+end
+
+function HDF5Group:_write_or_append(method, datapath, data, options)
+    assert(datapath and type(datapath) == 'table', "HDF5Group:" .. method .. "() expects table as first parameter")
+    assert(data, "HDF5Group:" .. method .. "() requires data as parameter")
     if #datapath == 0 then
         error("HDF5Group: descended too far")
     end
@@ -159,20 +267,26 @@ function HDF5Group:write(datapath, data, options)
         for k = 1, #datapath do
             datapath[k] = datapath[k+1]
         end
-        return child:write(datapath, data, options)
+        return child[method](child, datapath, data, options)
     end
 
     if type(data) == 'table' then
         local child = self:getOrCreateChild(key)
         for k, v in pairs(data) do
-            child:write({k}, v, options)
+            child[method](child, {k}, v, options)
         end
         return
     end
 
-    hdf5._logger.debug("Writing " .. (torch.typename(data) or type(data))
+    hdf5._logger.debug(method .. " " .. (torch.typename(data) or type(data))
                        .. " as '" .. key .. "' in " .. tostring(self))
-    local child = self:_writeData(self._groupID, key, data, options)
+
+    local child
+    if method == "write" then
+      child = self:_writeData(self._groupID, key, data, options)
+    elseif method == "append" then
+      child = self:_appendData(self._groupID, key, data, options)
+    end
     if not child then
         error("HDF5Group: error writing '" .. key .. "' in " .. tostring(self))
     end

--- a/luasrc/group.lua
+++ b/luasrc/group.lua
@@ -196,6 +196,11 @@ function HDF5Group:_appendDataSet(locationID, name, tensor, options)
     error("Error writing to hyperslab for data " .. name .. " to " .. tostring(self))
   end
 
+  status = hdf5.C.H5Sclose(memspaceID)
+  if status < 0 then
+    error("Failed closing memspace when appending for " .. tostring(self))
+  end
+
   return dataset
 end
 

--- a/luasrc/init.lua
+++ b/luasrc/init.lua
@@ -7,7 +7,6 @@ Torch support for the HDF5 Hierarchical Data Format.
 This format is fast and flexible, and is used by many scientific applications (Matlab, R, Python, etc)
 
 ]]
-
 hdf5 = {}
 
 require 'logroll'

--- a/tests/testChunking.lua
+++ b/tests/testChunking.lua
@@ -3,8 +3,8 @@
 Test chunking options.
 
 ]]
-
 require 'hdf5'
+
 local path = require 'pl.path'
 local totem = require 'totem'
 local tester = totem.Tester()
@@ -97,4 +97,71 @@ function myTests:testReadPartial()
     end)
 end
 
-tester:add(myTests):run()
+function myTests:testChunkedAppend()
+    testUtils.withTmpDir(function(tmpDir)
+        local h5filename = path.join(tmpDir, "foo.h5")
+        local h5file = hdf5.open(h5filename)
+        local options = hdf5.DataSetOptions()
+        options:setChunked(4, 4)
+
+        local data = torch.zeros(13, 13)
+        local k = 0
+        data:apply(function(x)
+            k = k + 1
+            return k
+        end)
+
+        -- write the initial data
+        h5file:write("data", data, options)
+        h5file:close()
+        tester:assert(path.isfile(h5filename), "file should exist")
+
+        -- reopen and verify that the original data is present
+        local h5readFile = hdf5.open(h5filename)
+        do
+            local selection = { 3, { 1, 4 } }
+            local read = h5readFile:read("data"):partial(unpack(selection))
+            tester:assertTensorEq(read:resize(4), data[selection], 1e-16, "Partial read returned wrong data")
+        end
+        h5readFile:close()
+
+        -- reopen and verify that the original data is present
+        local h5rwFile = hdf5.open(h5filename, 'r+')
+
+        local appendData = torch.zeros(13, 13)
+        local k = 13 * 13
+        appendData:apply(function(x)
+            k = k + 1
+            return k
+        end)
+
+        -- append data to the file
+        h5rwFile:append("data", appendData, options)
+
+        local function ensureBothOldAndNewData(file)
+          do --- ensure old data
+            local selection = { 3, { 1, 4 } }
+            local read = file:read("data"):partial(unpack(selection))
+            tester:assertTensorEq(read:resize(4), data[selection], 1e-16, "Partial read returned wrong data")
+          end
+
+          do --- ensure new data
+            local selection = { 16, { 1, 4 } }
+            local read = file:read("data"):partial(unpack(selection))
+            tester:assertTensorEq(read:resize(4), appendData[{3, {1, 4}}], 1e-16, "Partial read returned wrong data")
+          end
+        end
+
+        -- make sure our old and new data is present
+        ensureBothOldAndNewData(h5rwFile)
+        h5rwFile:close()
+
+        -- reopen to make sure it's still there
+        local h5readFile2 = hdf5.open(h5filename)
+        ensureBothOldAndNewData(h5readFile2)
+        h5readFile2:close()
+    end)
+end
+
+
+return tester:add(myTests):run()


### PR DESCRIPTION
This pull req adds the ability to append to chunked files as described here: http://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/examples/h5_extend.c

It also includes a test.

One part I'm not sure of is the best time to call `H5Sclose` on the new memory space that's created for the extended dataset. You can [see here](https://github.com/FieldDayTech/torch-hdf5/compare/deepmind:master...master#diff-e806d97a40e6b2cce3409e96905e9968R199]) that I'm calling close after the `H5Dwrite`, and this seems to work in my tests (e.g. the new data is still readable through `partial`, even without reopening the file).

It seems that if we wait until traditional `close` time, we might run the risk of accumulating that memory when we don't intend to e.g. in the case where we are doing several appends in a single session. That said, I'd be glad for another pair of eyes on it.
