### PR TITLE
fixed memory leak

### DIFF
--- a/luasrc/dataset.lua
+++ b/luasrc/dataset.lua
@@ -149,10 +149,11 @@ function HDF5DataSet:partial(...)
     -- Read data into the tensor
     local dataPtr = tensor:data()
     status = hdf5.C.H5Dread(self._datasetID, nativeType, tensorDataspace, self._dataspaceID, hdf5.H5P_DEFAULT, dataPtr)
-    if status < 0 then
-        error("HDF5DataSet:partial() - failed reading data from " .. tostring(self))
-    end
-    -- TODO delete tensor dataspace
+    -- delete tensor dataspace
+    local dataspace_status = hdf5.C.H5Sclose(tensorDataspace) 
+
+    assert(status >=0, "HDF5DataSet:partial() - failed reading data from " .. tostring(self))
+    assert(dataspace_status >= 0, "HDF5DataSet:partial() - error closing tensor dataspace for " .. tostring(self))
     return tensor
 end
 


### PR DESCRIPTION
The [HDF5 API](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5S.html#Dataspace-CreateSimple) says of the function *H5Screate_simple*

> The dataspace identifier returned from this function must be released with H5Sclose or resource leaks will occur.

But *H5Screate_simple* is called at https://github.com/deepmind/torch-hdf5/blob/master/luasrc/dataset.lua#L33, and H5Sclose never called on the returned dataspace.

This was causing a memory leak for me when querying an HDF5 file thousands of times for small (~1MB) chunks of data. Should be fixed now.