### PR TITLE
float16

### DIFF
--- a/luasrc/ffi.lua
+++ b/luasrc/ffi.lua
@@ -323,7 +323,7 @@ function hdf5._getTorchType(typeID)
         end
         error("Cannot support reading integer data with size = " .. size .. " bytes")
     elseif className == 'FLOAT' then
-        if size == 4 then
+        if size == 2 or size == 4 then
             return 'torch.FloatTensor'
         end
         if size == 8 then


### PR DESCRIPTION
I have imprecise floating points that I'd like to keep small. I made this change to the torch-hdf5 code, and it seems to work fine. Am I overlooking anything here?