### PR TITLE
Add note clarifying the use of torch-provided luarocks

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -14,6 +14,8 @@
     cd torch-hdf5
     luarocks make hdf5-0-0.rockspec
 
+Note: if `luarocks make` fails with an unsatisfied dependency, the luarocks being used is likely not the one provided by torch. Try using `[torch install directory]/install/bin/luarocks` instead.
+
 ### Ubuntu < 13.04
 
     sudo apt-get install libhdf5-serial-dev hdf5-tools


### PR DESCRIPTION
As described in #62, on OSX is is common that `luarocks` will resolve to the homebrew-installed luarocks or some other executable than that provided by torch. This PR proposes adding a note to clarify that the executable installed by torch should be used in the event that a dependency issue is encountered; when I ran into this I thought to look through closed issues, but that may not be immediately obvious to all users.