### PR TITLE
Fix memory leak resulting from H5Dget_space being called twice

### DIFF
--- a/luasrc/dataset.lua
+++ b/luasrc/dataset.lua
@@ -41,12 +41,12 @@ local function createTensorDataspace(tensor)
     return dataspaceID
 end
 
-function HDF5DataSet:__init(parent, datasetID)
+function HDF5DataSet:__init(parent, datasetID, dataspaceID)
     assert(parent)
     assert(datasetID)
     self._parent = parent
     self._datasetID = datasetID
-    self._dataspaceID = hdf5.C.H5Dget_space(self._datasetID)
+    self._dataspaceID = dataspaceID or hdf5.C.H5Dget_space(self._datasetID)
     hdf5._logger.debug("Initialising " .. tostring(self))
 end
 


### PR DESCRIPTION
### Problem

`H5Dget_space` is currently called twice, with the dataspace from the first call never being closed. This causes a memory leak which is particularly severe when opening many HDF5 files. I have personally had this bug crash the training of a neural network after 15 hours (with no error message), which is incredibly frustrating.

1. The first dataspace is created with `H5Dget_space` at https://github.com/deepmind/torch-hdf5/blob/a4f80cbc1d6f53cda3b890fd96a846046a6b0424/luasrc/init.lua#L81. This returns `dataspaceID`.
2. `dataspaceID` is passed to the HDF5DataSet at https://github.com/deepmind/torch-hdf5/blob/a4f80cbc1d6f53cda3b890fd96a846046a6b0424/luasrc/init.lua#L85.
3. HDF5DataSet currently does not accept a `dataspaceID` constructor argument and creates another one with `H5Dget_space`. The first `dataspaceID` is lost and never freed, leading to a memory leak.

### Proposed solution

Accept `dataspaceID` as a constructor argument in HDF5DataSet.