### PR TITLE
fix: HDF5File.__init() requires a fileID

### DIFF
--- a/luasrc/file.lua
+++ b/luasrc/file.lua
@@ -140,10 +140,12 @@ function hdf5.HDF5File.open(filename, mode)
     end
     local function createFunc(filename, access)
         local fileID = hdf5.C.H5Fcreate(filename, access, hdf5.H5P_DEFAULT, hdf5.H5P_DEFAULT)
+		fileID = tonumber(fileID) --HDF5File:__init wants a "number"
         return hdf5.HDF5File(filename, fileID)
     end
     local function openFunc(filename, access)
         local fileID = hdf5.C.H5Fopen(filename, access, hdf5.H5P_DEFAULT)
+		fileID = tonumber(fileID) --HDF5File:__init wants a "number"
         return hdf5.HDF5File(filename, fileID)
     end
     if mode == 'r' then

--- a/luasrc/group.lua
+++ b/luasrc/group.lua
@@ -85,7 +85,7 @@ function HDF5Group.__read(object, self, versionNumber)
 end
 
 function HDF5Group:__tostring()
-    return "[HDF5Group " .. self._groupID .. " " .. hdf5._getObjectName(self._groupID) .. "]"
+    return "[HDF5Group " .. tostring(self._groupID) .. " " .. hdf5._getObjectName(self._groupID) .. "]"
 end
 
 function HDF5Group:_writeDataSet(locationID, name, tensor, options)


### PR DESCRIPTION
The constructor wants a "number" so we convert to it.
Issue #81