### PR TITLE
Pass includePath to gcc so it can find include files

### DIFF
--- a/luasrc/ffi.lua
+++ b/luasrc/ffi.lua
@@ -41,9 +41,12 @@ local function loadHDF5Header(includePath)
     if not path.isfile(headerPath) then
         error("Error: unable to locate HDF5 header file at " .. headerPath)
     end
-    local process = io.popen("gcc -E " .. headerPath .. " -I " .. includePath) -- TODO detect and handle failure to parse
+    local process = io.popen("gcc -E " .. headerPath .. " -I " .. includePath)
     local contents = process:read("*all")
-    process:close()
+    local success, errorMsg, returnCode = process:close()
+    if returnCode ~= 0 then
+        error("Error: unable to parse HDF5 header file at " .. headerPath)
+    end
 
     -- Strip out the extra junk that GCC returns
     local cdef = ""

--- a/luasrc/ffi.lua
+++ b/luasrc/ffi.lua
@@ -41,7 +41,7 @@ local function loadHDF5Header(includePath)
     if not path.isfile(headerPath) then
         error("Error: unable to locate HDF5 header file at " .. headerPath)
     end
-    local process = io.popen("gcc -E " .. headerPath) -- TODO pass -I
+    local process = io.popen("gcc -E " .. headerPath .. " -I " .. includePath) -- TODO detect and handle failure to parse
     local contents = process:read("*all")
     process:close()
 


### PR DESCRIPTION
Pretty much what the commit comment says: Pass includePath to gcc so it can find include files that might not be on the system path.

Without this fix, gcc can fail because it doesn't find include files such as mpi.h.  However since, the return status isn't checked (see note below) the loadHDF5Header continues along as if all was well, until things finally barf on an undefined symbol call to hdf5.C.H5Open().

Note: I'll work on a fix that includes better checking of the io.popen() call.  But since my entire Lua knowledge consists of what I've learned in the past two days trying to track this bug down, it might be a bit.  In the meantime, this fix at least gets folks up and running and provides a basis for improvement.